### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/EXFE/EFAPIServer.m
+++ b/EXFE/EFAPIServer.m
@@ -193,7 +193,7 @@ NSString *kEFAPIErrorDomain = @"errorDomain.efapi";
                                                          needInsertNew = YES;
                                                      }
                                                  };
-                                                 if (dispatch_get_current_queue() != dispatch_get_main_queue()) {
+                                                 if (![NSThread isMainThread]) {
                                                      dispatch_sync(dispatch_get_main_queue(), block);
                                                  } else {
                                                      block();
@@ -216,7 +216,7 @@ NSString *kEFAPIErrorDomain = @"errorDomain.efapi";
                                                          [identityEntities addObject:identity];
                                                      }];
                                                  };
-                                                 if (dispatch_get_current_queue() != dispatch_get_main_queue()) {
+                                                 if (![NSThread isMainThread]) {
                                                      dispatch_sync(dispatch_get_main_queue(), block);
                                                  } else {
                                                      block();

--- a/EXFE/EFChoosePeopleViewController.m
+++ b/EXFE/EFChoosePeopleViewController.m
@@ -965,7 +965,7 @@
         
         recentexfeePeople = [result autorelease];
     };
-    if (dispatch_get_current_queue() != dispatch_get_main_queue()) {
+    if (![NSThread isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), block);
     } else {
         block();

--- a/EXFE/EFContactDataSource.m
+++ b/EXFE/EFContactDataSource.m
@@ -272,7 +272,7 @@
         }
     };
     
-    if (dispatch_get_current_queue() != dispatch_get_main_queue()) {
+    if (![NSThread isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), block);
     } else {
         block();

--- a/EXFE/EFImageCache.m
+++ b/EXFE/EFImageCache.m
@@ -16,7 +16,7 @@
 
 - (UIImage *)imageForKey:(NSString *)key {
     NSParameterAssert(key);
-    NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"MUST called on main thread.");
+    NSAssert([NSThread isMainThread], @"MUST called on main thread.");
     
     return [self objectForKey:key];
 }
@@ -24,7 +24,7 @@
 - (void)setImage:(UIImage *)image forKey:(NSString *)key {
     NSParameterAssert(image);
     NSParameterAssert(key);
-    NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"MUST called on main thread.");
+    NSAssert([NSThread isMainThread], @"MUST called on main thread.");
     
     [self setObject:image forKey:key];
 }

--- a/EXFE/EFMapStrokeView.m
+++ b/EXFE/EFMapStrokeView.m
@@ -95,7 +95,7 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"MUST be on main thread.");
+    NSAssert([NSThread isMainThread], @"MUST be on main thread.");
     
     CGContextRef context = UIGraphicsGetCurrentContext();
     
@@ -138,7 +138,7 @@
 #pragma mark - Public
 
 - (void)reloadData {
-    NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"MUST be on main thread.");
+    NSAssert([NSThread isMainThread], @"MUST be on main thread.");
     
     CLLocationCoordinate2D cooridnate = self.mapView.centerCoordinate;
     CGPoint center = [self.mapView convertCoordinate:cooridnate toPointToView:self.superview];

--- a/EXFE/NewGatherViewController.m
+++ b/EXFE/NewGatherViewController.m
@@ -1001,7 +1001,7 @@
         [self hideMenu];
         
         void (^addActionHandler)(NSArray *contactObjects) = ^(NSArray *contactObjects){
-            NSAssert(dispatch_get_main_queue() == dispatch_get_current_queue(), @"WTF! MUST on main queue! boy!");
+            NSAssert([NSThread isMainThread], @"MUST on main queue! boy!");
             
             [self dismissViewControllerAnimated:YES completion:nil];
             

--- a/EXFE/WidgetExfeeViewController.m
+++ b/EXFE/WidgetExfeeViewController.m
@@ -965,7 +965,7 @@ typedef enum {
     if (section == 1) {
         if (indexPath.row == self.sortedInvitations.count){
             void (^addActionHandler)(NSArray *contactObjects) = ^(NSArray *contactObjects){
-                NSAssert(dispatch_get_main_queue() == dispatch_get_current_queue(), @"WTF! MUST on main queue! boy!");
+                NSAssert([NSThread isMainThread], @"MUST on main queue! boy!");
                 
 //                MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
 //                hud.labelText = @"Adding...";


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h:

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
